### PR TITLE
[44기 김정환] Footer 컴포넌트 추가, Products(상품 리스트) 페이지에서 장바구니 담기 기능 추가

### DIFF
--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { FOOTER_LINKS_DATA } from './footerData';
+import Icons from '../Icons/Icons';
 import './Footer.scss';
 
 const Footer = () => {
@@ -32,6 +33,22 @@ const Footer = () => {
               ))}
             </div>
           ))}
+        </div>
+      </div>
+      <div className="row-bottom">
+        <div className="social-container">
+          <div className="icon">
+            <Icons name="Facebook" width={20} height={20} />
+          </div>
+          <div className="icon">
+            <Icons name="Instagram" width={20} height={20} />
+          </div>
+          <div className="icon">
+            <Icons name="Youtube" width={20} height={20} />
+          </div>
+          <div className="icon">
+            <Icons name="MessageCircle" width={20} height={20} />
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -1,8 +1,41 @@
 import React from 'react';
+import { FOOTER_LINKS_DATA } from './footerData';
 import './Footer.scss';
 
 const Footer = () => {
-  return <div>FOOTER</div>;
+  return (
+    <div className="footer">
+      <div className="row-top">
+        <div className="section-left">
+          <div className="header">WEKEA Family</div>
+          <div className="text">
+            지금 WEKEA Family에 무료로 가입하고 다양한 멤버 전용 혜택을
+            누리세요.
+          </div>
+          <div className="link">자세히 보기</div>
+          <div className="button">WEKEA Family 가입하기</div>
+          <div className="header">WEKEA Business Network 가입하기</div>
+          <div className="text">
+            여러분의 더 나은 비즈니스 환경을 위한 다양한 혜택들을 받으세요.
+          </div>
+          <div className="link">자세히 보기</div>
+          <div className="button">WEKEA Business Network 가입하기</div>
+        </div>
+        <div className="section-right">
+          {FOOTER_LINKS_DATA.map(({ id, header, subMenu }) => (
+            <div key={id} className="column">
+              <div className="header">{header}</div>
+              {subMenu.map(({ id, menu }) => (
+                <div key={id} className="text">
+                  {menu}
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export default Footer;

--- a/src/components/Footer/Footer.scss
+++ b/src/components/Footer/Footer.scss
@@ -1,0 +1,64 @@
+@import '../../styles/mixin';
+@import '../../styles/variables';
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&family=Noto+Sans:wght@300&display=swap');
+.footer {
+  padding: 80px 90px 80px 180px;
+  background-color: rgb(245, 245, 245);
+  font-family: 'Noto Sans KR', sans-serif;
+
+  .row-top {
+    display: flex;
+    width: 100%;
+  }
+  .header {
+    margin-bottom: 24px;
+    font-size: 16px;
+    font-weight: 700;
+  }
+
+  .text {
+    margin-bottom: 16px;
+    color: #484848;
+    font-size: 14px;
+    font-weight: 300;
+    line-height: 1.4;
+  }
+
+  .section-left {
+    width: 23%;
+
+    .link {
+      margin-bottom: 20px;
+      color: #111111;
+      font-size: 14px;
+      font-weight: 300;
+      text-decoration: underline;
+    }
+
+    .button {
+      display: inline-block;
+      margin-bottom: 60px;
+      padding: 12px 24px;
+      transition: 0.3s;
+      border-radius: 45px;
+      background-color: #111111;
+      color: #ffffff;
+      font-size: 14px;
+      font-weight: 700;
+      cursor: pointer;
+
+      &:hover {
+        background-color: #555555;
+      }
+    }
+  }
+  .section-right {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr 1fr;
+    width: 70%;
+
+    .column {
+      padding: 0 36px;
+    }
+  }
+}

--- a/src/components/Footer/Footer.scss
+++ b/src/components/Footer/Footer.scss
@@ -9,56 +9,59 @@
   .row-top {
     display: flex;
     width: 100%;
-  }
-  .header {
-    margin-bottom: 24px;
-    font-size: 16px;
-    font-weight: 700;
-  }
 
-  .text {
-    margin-bottom: 16px;
-    color: #484848;
-    font-size: 14px;
-    font-weight: 300;
-    line-height: 1.4;
-  }
+    .header {
+      margin-bottom: 24px;
+      font-size: 16px;
+      font-weight: 700;
+    }
 
-  .section-left {
-    width: 23%;
-
-    .link {
-      margin-bottom: 20px;
-      color: #111111;
+    .text {
+      margin-bottom: 16px;
+      color: #484848;
       font-size: 14px;
       font-weight: 300;
-      text-decoration: underline;
+      line-height: 1.4;
     }
 
-    .button {
-      display: inline-block;
-      margin-bottom: 60px;
-      padding: 12px 24px;
-      transition: 0.3s;
-      border-radius: 45px;
-      background-color: #111111;
-      color: #ffffff;
-      font-size: 14px;
-      font-weight: 700;
-      cursor: pointer;
+    .section-left {
+      width: 23%;
+      padding-right: 36px;
 
-      &:hover {
-        background-color: #555555;
+      .link {
+        margin-bottom: 20px;
+        color: #111111;
+        font-size: 14px;
+        font-weight: 300;
+        text-decoration: underline;
+        cursor: pointer;
+      }
+
+      .button {
+        display: inline-block;
+        margin-bottom: 60px;
+        padding: 12px 24px;
+        transition: 0.3s;
+        border-radius: 45px;
+        background-color: #111111;
+        color: #ffffff;
+        font-size: 14px;
+        font-weight: 700;
+        cursor: pointer;
+
+        &:hover {
+          background-color: #555555;
+        }
       }
     }
-  }
-  .section-right {
-    display: grid;
-    grid-template-columns: 1fr 1fr 1fr 1fr;
-    width: 70%;
+    .section-right {
+      display: grid;
+      grid-template-columns: 1fr 1fr 1fr 1fr;
+      width: 70%;
 
-    .column {
-      padding: 0 36px;
+      .column {
+        padding: 0 36px;
+      }
     }
   }
 }

--- a/src/components/Footer/footerData.js
+++ b/src/components/Footer/footerData.js
@@ -92,6 +92,44 @@ export const FOOTER_LINKS_DATA = [
     ],
   },
   {
+    id: 3,
+    header: '서비스',
+    subMenu: [
+      {
+        id: 1,
+        menu: 'wEKEA 서비스',
+      },
+      {
+        id: 2,
+        menu: '배송 서비스',
+      },
+      {
+        id: 3,
+        menu: '조립 서비스',
+      },
+      {
+        id: 4,
+        menu: '설치 서비스',
+      },
+      {
+        id: 5,
+        menu: '주방 서비스',
+      },
+      {
+        id: 6,
+        menu: '구매 상담 서비스',
+      },
+      {
+        id: 7,
+        menu: '인테리어 디자인 서비스',
+      },
+      {
+        id: 8,
+        menu: '바이백 서비스',
+      },
+    ],
+  },
+  {
     id: 4,
     header: 'WEKEA 이야기',
     subMenu: [

--- a/src/components/Footer/footerData.js
+++ b/src/components/Footer/footerData.js
@@ -1,0 +1,124 @@
+export const FOOTER_LINKS_DATA = [
+  {
+    id: 1,
+    header: '고객문의',
+    subMenu: [
+      {
+        id: 1,
+        menu: '고객지원',
+      },
+      {
+        id: 2,
+        menu: '자주 묻는 질문',
+      },
+      {
+        id: 3,
+        menu: '문의하기',
+      },
+      {
+        id: 4,
+        menu: '문의하기',
+      },
+      {
+        id: 5,
+        menu: '배송조회',
+      },
+      {
+        id: 6,
+        menu: '교환환불',
+      },
+      {
+        id: 7,
+        menu: '품질보증',
+      },
+      {
+        id: 8,
+        menu: '제품리콜',
+      },
+      {
+        id: 9,
+        menu: '피드백',
+      },
+      {
+        id: 10,
+        menu: '부품 신청',
+      },
+    ],
+  },
+  {
+    id: 2,
+    header: '쇼핑하기',
+    subMenu: [
+      {
+        id: 1,
+        menu: '쇼핑하기',
+      },
+      {
+        id: 2,
+        menu: 'WEKEA for Business',
+      },
+      {
+        id: 3,
+        menu: '헤이오더',
+      },
+      {
+        id: 4,
+        menu: '셀프 플래닝',
+      },
+      {
+        id: 5,
+        menu: 'WEKEA 모바일 앱',
+      },
+      {
+        id: 6,
+        menu: '제품 사용 팁/가이드',
+      },
+      {
+        id: 7,
+        menu: '제품 구매 가이드',
+      },
+      {
+        id: 8,
+        menu: '브로슈어',
+      },
+      {
+        id: 9,
+        menu: '결제 옵션',
+      },
+      {
+        id: 10,
+        menu: '기프트 카드',
+      },
+    ],
+  },
+  {
+    id: 4,
+    header: 'WEKEA 이야기',
+    subMenu: [
+      {
+        id: 1,
+        menu: '브랜드 소개',
+      },
+      {
+        id: 2,
+        menu: '집에서의 생활',
+      },
+      {
+        id: 3,
+        menu: '지속가능한 생활',
+      },
+      {
+        id: 4,
+        menu: '내가 아끼는 집, 나를 아끼는 집',
+      },
+      {
+        id: 5,
+        menu: '뉴스룸',
+      },
+      {
+        id: 6,
+        menu: '제품 정보',
+      },
+    ],
+  },
+];

--- a/src/components/Icons/Icons.js
+++ b/src/components/Icons/Icons.js
@@ -14,6 +14,10 @@ import {
   Home,
   X,
   ChevronRight,
+  Facebook,
+  Instagram,
+  Youtube,
+  MessageCircle,
 } from 'react-feather';
 
 const Icons = ({ name, width, height, className = '' }) => {
@@ -41,6 +45,14 @@ const Icons = ({ name, width, height, className = '' }) => {
     Tool: <Tool width={width} height={height} className={className} />,
     ShoppingBag: (
       <ShoppingBag width={width} height={height} className={className} />
+    ),
+    Facebook: <Facebook width={width} height={height} className={className} />,
+    Instagram: (
+      <Instagram width={width} height={height} className={className} />
+    ),
+    Youtube: <Youtube width={width} height={height} className={className} />,
+    MessageCircle: (
+      <MessageCircle width={width} height={height} className={className} />
     ),
   };
 

--- a/src/components/Nav/SideNav/SecondLevelMenu/SecondLevelMenus.js
+++ b/src/components/Nav/SideNav/SecondLevelMenu/SecondLevelMenus.js
@@ -14,7 +14,6 @@ const SecondLevelMenus = ({ currentTopMenu, handleSubMenuClick }) => {
           <React.Fragment key={menu.id}>
             <div
               onClick={() => {
-                console.log(menu.id, 'clicked');
                 handleSubMenuClick(menu.id);
               }}
               className="second-level-menus"

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,4 @@
-export const BASE_URL = 'http://10.58.52.133:3000';
+export const BASE_URL = 'http://10.58.52.225:3000';
 
 export const APIS = {
   signin: `${BASE_URL}/users/signin`,

--- a/src/pages/Cart/Cart.js
+++ b/src/pages/Cart/Cart.js
@@ -30,7 +30,6 @@ const Cart = () => {
     })
       .then(response => response.json())
       .then(result => {
-        console.log(result);
         setCartData(result);
       });
   }, []);
@@ -54,15 +53,12 @@ const Cart = () => {
   };
 
   const handleSubmit = () => {
-    // TODO: 아래 fetch함수를 위한 변수 선언
     const bodyData = cartData?.map(item => {
       return {
         id: item.id,
         quantity: item.quantity,
       };
     });
-
-    console.log(bodyData);
 
     fetch(`${APIS.cart}`, {
       method: 'PUT',
@@ -72,7 +68,6 @@ const Cart = () => {
         Authorization: token,
       },
       body: JSON.stringify({
-        // TODO: 백엔드가 받기 원하는 게 아이디와 수량뿐일 경우, 위 bodyData 변수를 사용
         productList: bodyData,
       }),
     })

--- a/src/pages/Cart/Cart.js
+++ b/src/pages/Cart/Cart.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import Icons from '../../components/Icons/Icons';
 import CartItem from './CartItem/CartItem';
 import { APIS } from '../../config';
@@ -9,7 +10,7 @@ const Cart = () => {
   useEffect(() => {
     fetch(`${APIS.cart}`, {
       method: 'GET',
-      headers: {
+      heas: {
         'Content-Type': 'application/json',
         Accept: 'application/json',
       },
@@ -19,6 +20,8 @@ const Cart = () => {
         setCartData(result);
       });
   }, []);
+
+  const navigate = useNavigate();
 
   const totalCost = cartData
     .map(item => item.cost * item.quantity)
@@ -48,7 +51,10 @@ const Cart = () => {
 
   const token = localStorage.getItem('token');
 
-  if (!token) return <div>잘못된 페이지 입니다.</div>;
+  if (!token) {
+    alert('장바구니를 이용하려면 로그인 해주세요!');
+    return <button>로그인 페이지로 이동하기</button>;
+  }
 
   return (
     <div className="cart">

--- a/src/pages/Cart/Cart.js
+++ b/src/pages/Cart/Cart.js
@@ -22,7 +22,7 @@ const Cart = () => {
   useEffect(() => {
     fetch(`${APIS.cart}`, {
       method: 'GET',
-      heas: {
+      headers: {
         'Content-Type': 'application/json',
         Accept: 'application/json',
         Authorization: token,
@@ -30,13 +30,16 @@ const Cart = () => {
     })
       .then(response => response.json())
       .then(result => {
+        console.log(result);
         setCartData(result);
       });
   }, []);
 
-  const totalCost = cartData
-    ?.map(({ quantity, price }) => quantity * price)
-    .reduce((acc, cur) => acc + cur, 0);
+  const totalCost =
+    cartData &&
+    cartData
+      .map(({ quantity, price }) => quantity * price)
+      .reduce((acc, cur) => acc + cur, 0);
 
   const handleAmountChange = (id, num) => {
     const updatedData = cartData?.map(item =>
@@ -52,24 +55,26 @@ const Cart = () => {
 
   const handleSubmit = () => {
     // TODO: 아래 fetch함수를 위한 변수 선언
-    // const bodyData = cartData?.map(item => {
-    //   return {
-    //     id: item.id,
-    //     quantity: item.quantity,
-    //   };
-    // });
+    const bodyData = cartData?.map(item => {
+      return {
+        id: item.id,
+        quantity: item.quantity,
+      };
+    });
+
+    console.log(bodyData);
 
     fetch(`${APIS.cart}`, {
-      method: 'POST',
+      method: 'PUT',
       headers: {
         'Content-Type': 'application/json',
         Accept: 'application/json',
         Authorization: token,
       },
-      body: {
+      body: JSON.stringify({
         // TODO: 백엔드가 받기 원하는 게 아이디와 수량뿐일 경우, 위 bodyData 변수를 사용
-        whateverthekeyis: cartData,
-      },
+        productList: bodyData,
+      }),
     })
       .then(response => response.json())
       .then(result => {

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -72,8 +72,15 @@ function Login() {
       <div className="left">
         <div className="column-content">
           <div className="column-top">
-            <ArrowLeft className="arrow-left" />
-            <div className="wekea-logo-white" />
+            <div
+              onClick={() => {
+                navigate(-1);
+              }}
+              className="icon-btn-wrap"
+            >
+              <ArrowLeft className="arrow-left" />
+            </div>
+            <div onClick={() => navigate('/')} className="wekea-logo-white" />
           </div>
           <div className="hero-wrapper">
             <h1 className="title">로그인</h1>

--- a/src/pages/Login/Login.scss
+++ b/src/pages/Login/Login.scss
@@ -1,4 +1,5 @@
 @import '../../styles/variables';
+@import '../../styles/mixin';
 @import url('https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;600;700&display=swap');
 
 .login {
@@ -18,12 +19,31 @@
       align-items: center;
       // justify-content: center;
 
-      .arrow-left {
+      .icon-btn-wrap {
+        @include flexCenter;
         position: absolute;
         left: 32px;
         width: 22px;
+        width: 36px;
         height: 22px;
-        color: #ffffff;
+        height: 36px;
+        transition: 0.3s;
+        border-radius: 50%;
+
+        &:hover {
+          background-color: #d8d8d8;
+        }
+
+        .arrow-left {
+          transition: 0.3s;
+          border-radius: 50%;
+          color: #ffffff;
+          cursor: pointer;
+
+          &:hover {
+            color: $ikea-blue;
+          }
+        }
       }
 
       .wekea-logo-white {

--- a/src/pages/Main/Main.js
+++ b/src/pages/Main/Main.js
@@ -24,7 +24,6 @@ function Main() {
     })
       .then(response => response.json())
       .then(data => {
-        console.log(data);
         setProductsData(data);
       });
   }, []);

--- a/src/pages/Order/Modal/Modal.js
+++ b/src/pages/Order/Modal/Modal.js
@@ -40,7 +40,9 @@ const Modal = ({ modalOpen, setModalOpen, data }) => {
       body: {},
     })
       .then(response => response.json())
-      .then(result => console.log(result));
+      .then(result => {
+        return result;
+      });
     setPaymentComplete(true);
   };
 

--- a/src/pages/Order/Order.js
+++ b/src/pages/Order/Order.js
@@ -52,15 +52,13 @@ const Order = () => {
       body: JSON.stringify({}),
     })
       .then(response => response.json())
-      .then(result => console.log(result));
+      .then(result => {
+        return result;
+      });
     setModalOpen(!modalOpen);
   };
 
   const formNotComplete = delivery === false || terms === false;
-
-  // const { message } = orderData;
-
-  console.log(orderData);
 
   return (
     <div className="order">

--- a/src/pages/Order/Order.js
+++ b/src/pages/Order/Order.js
@@ -71,7 +71,7 @@ const Order = () => {
       )}
 
       <div className="section-top">
-        <div className="logo" />
+        <div onClick={() => navigate('/')} className="logo" />
       </div>
       <div className="section-main">
         <div className="section-text">

--- a/src/pages/Order/Order.js
+++ b/src/pages/Order/Order.js
@@ -6,7 +6,7 @@ import { APIS } from '../../config';
 import './Order.scss';
 
 const Order = () => {
-  const [orderData, setOrderData] = useState([]);
+  const [orderData, setOrderData] = useState();
   const [modalOpen, setModalOpen] = useState(false);
   const navigate = useNavigate();
 
@@ -49,7 +49,7 @@ const Order = () => {
         Accept: 'application/json',
         Authorization: token,
       },
-      body: {},
+      body: JSON.stringify({}),
     })
       .then(response => response.json())
       .then(result => console.log(result));
@@ -58,7 +58,9 @@ const Order = () => {
 
   const formNotComplete = delivery === false || terms === false;
 
-  const { message } = orderData;
+  // const { message } = orderData;
+
+  console.log(orderData);
 
   return (
     <div className="order">
@@ -66,7 +68,7 @@ const Order = () => {
         <Modal
           modalOpen={() => setModalOpen(!modalOpen)}
           setModalOpen={setModalOpen}
-          data={message}
+          data={orderData}
         />
       )}
 
@@ -79,7 +81,7 @@ const Order = () => {
             <div className="step-header">배송과 픽업 방법</div>
           </div>
           <div className="delivery-address">배송지:</div>
-          <div className="address-text">{message?.userInfo[0].addresses}</div>
+          <div className="address-text">{orderData?.userInfo}</div>
           <div onClick={() => navigate('/cart')} className="fix-address">
             수정
           </div>
@@ -124,7 +126,7 @@ const Order = () => {
             <div className="cost">
               <div className="total">총 주문금액</div>
               <div className="cost-num">
-                ₩&nbsp;{message?.totalAmount.toLocaleString()}
+                ₩&nbsp;{orderData?.totalAmount.toLocaleString()}
               </div>
             </div>
             <div className="terms-wrapper">
@@ -163,7 +165,7 @@ const Order = () => {
                 <div className="fix-link">수정</div>
               </div>
               <div className="item-thumb-container">
-                {message?.imageUrl.map((link, i) => (
+                {orderData?.imageUrl.map((link, i) => (
                   <div
                     key={i}
                     style={{
@@ -179,7 +181,7 @@ const Order = () => {
               <div className="header">
                 <div className="sum-text">
                   <div>제품 가격 (배송비 제외)</div>
-                  <div>₩&nbsp;{message?.totalAmount.toLocaleString()}</div>
+                  <div>₩&nbsp;{orderData?.totalAmount.toLocaleString()}</div>
                 </div>
                 <div className="sum-text">
                   <div>배송비</div>
@@ -190,7 +192,7 @@ const Order = () => {
             <div className="cost">
               <div className="total">총 주문금액</div>
               <div className="cost-num">
-                ₩&nbsp;{message?.totalAmount.toLocaleString()}
+                ₩&nbsp;{orderData?.totalAmount.toLocaleString()}
               </div>
             </div>
             <div className="extra-info">

--- a/src/pages/ProductDetail/components 2/LikeButton/LikeButton 3.scss
+++ b/src/pages/ProductDetail/components 2/LikeButton/LikeButton 3.scss
@@ -1,0 +1,5 @@
+.like-button {
+  width: 25px;
+  height: 25px;
+  margin: 7px;
+}

--- a/src/pages/Products/components/MiniProduct.js
+++ b/src/pages/Products/components/MiniProduct.js
@@ -24,13 +24,13 @@ const MiniProduct = ({ id, names, sub_description, price, image_url }) => {
 
   return (
     <div className="mini-product" key={id}>
+      -
       <div
         style={{
           backgroundImage: `url(${image_url})`,
         }}
         className="img"
       />
-
       <div className="text-box">
         <p className="title">{names}</p>
         <p className="commit">{sub_description}</p>

--- a/src/pages/Products/components/MiniProduct.js
+++ b/src/pages/Products/components/MiniProduct.js
@@ -19,7 +19,9 @@ const MiniProduct = ({ id, names, sub_description, price, image_url }) => {
       }),
     })
       .then(response => response.json())
-      .then(result => console.log(result));
+      .then(result => {
+        return result;
+      });
   };
 
   return (
@@ -46,7 +48,6 @@ const MiniProduct = ({ id, names, sub_description, price, image_url }) => {
           <div className="cart-wrap">
             <button
               onClick={() => {
-                console.log(id);
                 handleAddCart(id);
               }}
               className="cart-btn"

--- a/src/pages/Products/components/MiniProduct.js
+++ b/src/pages/Products/components/MiniProduct.js
@@ -1,8 +1,27 @@
 import React from 'react';
 import { Heart, ShoppingCart } from 'react-feather';
+import { APIS } from '../../../config';
 import './MiniProduct.scss';
 
 const MiniProduct = ({ id, names, sub_description, price, image_url }) => {
+  const token = localStorage.getItem('token');
+
+  const handleAddCart = id => {
+    fetch(`${APIS.cart}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json;charset=utf-8',
+        Authorization: token,
+      },
+      body: JSON.stringify({
+        productId: id,
+        quantity: 1,
+      }),
+    })
+      .then(response => response.json())
+      .then(result => console.log(result));
+  };
+
   return (
     <div className="mini-product" key={id}>
       <div
@@ -25,7 +44,13 @@ const MiniProduct = ({ id, names, sub_description, price, image_url }) => {
 
         <div className="icon-box">
           <div className="cart-wrap">
-            <button className="cart-btn">
+            <button
+              onClick={() => {
+                console.log(id);
+                handleAddCart(id);
+              }}
+              className="cart-btn"
+            >
               <ShoppingCart className="cart-icon" />
             </button>
           </div>

--- a/src/pages/Signup/Signup.js
+++ b/src/pages/Signup/Signup.js
@@ -69,8 +69,6 @@ const Signup = () => {
   const handleSubmit = event => {
     event.preventDefault();
 
-    // allValueValidated && console.log(inputs);
-
     allValueValidated &&
       fetch(`${APIS.signup}`, {
         method: 'POST',
@@ -88,7 +86,9 @@ const Signup = () => {
         }),
       })
         .then(response => response.json())
-        .then(result => console.log(result));
+        .then(result => {
+          return result;
+        });
   };
 
   return (
@@ -179,7 +179,7 @@ const Signup = () => {
               </label>
             </span>
           </fieldset>
-          <form onSubmit={() => console.log(inputs)}>
+          <form onSubmit={handleSubmit}>
             {USER_INPUT_INFO_LIST.map(
               ({ id, label, name, type, placeholder }) => {
                 return (

--- a/src/pages/Signup/Signup.js
+++ b/src/pages/Signup/Signup.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { AlertCircle, ArrowLeft, CheckCircle } from 'react-feather';
 import { APIS } from '../../config';
 import './Signup.scss';
@@ -24,6 +24,8 @@ const Signup = () => {
   const { terms, privacy } = checkboxes;
 
   const { name, birth, phone, gender, email, address, password } = inputs;
+
+  const navigate = useNavigate();
 
   const handleInput = event => {
     const { name, value } = event.target;
@@ -94,8 +96,15 @@ const Signup = () => {
       <div className="section-left">
         <div className="column-content">
           <div className="column-top">
-            <ArrowLeft className="arrow-left" />
-            <div className="wekea-logo" />
+            <div
+              onClick={() => {
+                navigate(-1);
+              }}
+              className="icon-btn-wrap"
+            >
+              <ArrowLeft className="arrow-left" />
+            </div>
+            <div onClick={() => navigate('/')} className="wekea-logo" />
           </div>
           <h1 className="title">
             <span className="ikea-blue">WEKEA Family</span> 회원 가입

--- a/src/pages/Signup/Signup.scss
+++ b/src/pages/Signup/Signup.scss
@@ -17,11 +17,26 @@
       display: flex;
       align-items: center;
 
-      .arrow-left {
+      .icon-btn-wrap {
+        @include flexCenter;
         position: absolute;
         left: 32px;
         width: 22px;
+        width: 36px;
         height: 22px;
+        height: 36px;
+        transition: 0.3s;
+        border-radius: 50%;
+
+        &:hover {
+          background-color: #d8d8d8;
+        }
+
+        .arrow-left {
+          transition: 0.3s;
+          border-radius: 50%;
+          cursor: pointer;
+        }
       }
 
       .wekea-logo {

--- a/src/styles/common.scss
+++ b/src/styles/common.scss
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;600;700&display=swap');
+
 * {
   box-sizing: border-box;
   font-family: 'Noto Sans', sans-serif;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 보여야 하는 페이지에서만 보이는 푸터 컴포넌트 추가, 상품 리스트 페이지에서 상세로 넘어가지 않고 장바구니 버튼 눌렀을 때 장바구니 담는 기능 추가

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. useLocation 훅을 사용하여 login, signup 외 페이지에서 보이게 설정하였다.
- 테스트 방법 : `/login, /signup` 페이지 이동 >>> 확인
- 2. 상품 리스트 페이지에서 상세로 넘어가지 않고 장바구니 버튼 눌렀을 때 장바구니 담는 기능 추가
- 테스트 방법: products 페이지에서 상품의 장바구니 버튼 클릭

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- useLocation 훅을 추가로 공부하게 되었습니다.
<br />

## :: 기타 질문 및 특이 사항
- 현재 fetch함수들이 서버를 켜지 않았는데도 해당 엔드포인트로 요청이 가다 보니 라우팅을 하는 간단한 작업을 하는 중에도 에러가 많이 뜨는데, 이러한 경우에는 fetch 함수 요청 엔드포인트를 mock 데이터와 왔다갔다하면서 갈아끼워야되는지 궁금합니다!
